### PR TITLE
Correct bit per sample for speaker

### DIFF
--- a/components/tas5805m/Example YAML/esp32S3_louder_sendspin_mediaplayer.yaml
+++ b/components/tas5805m/Example YAML/esp32S3_louder_sendspin_mediaplayer.yaml
@@ -174,7 +174,7 @@ speaker:
     id: i2s_speaker_id
     sample_rate: 48000
     i2s_dout_pin: GPIO16
-    bits_per_sample: 32bit
+    bits_per_sample: 16bit
     dac_type: external
     channel: stereo
     timeout: never


### PR DESCRIPTION
changed bit depth for speaker to 16bit, otherwise left channel is not playing music with this example yaml configuration.